### PR TITLE
Fix mypy type error in count_matches function

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,7 @@
+Issue to solve: https://github.com/IlyaElevrin/wink_ai_model_/issues/3
+Your prepared branch: issue-3-3d79928ffe77
+Your prepared working directory: /tmp/gh-issue-solver-1763294963303
+Your forked repository: konard/wink_ai_model_
+Original repository (upstream): IlyaElevrin/wink_ai_model_
+
+Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,0 @@
-Issue to solve: https://github.com/IlyaElevrin/wink_ai_model_/issues/3
-Your prepared branch: issue-3-3d79928ffe77
-Your prepared working directory: /tmp/gh-issue-solver-1763294963303
-Your forked repository: konard/wink_ai_model_
-Original repository (upstream): IlyaElevrin/wink_ai_model_
-
-Proceed.

--- a/ml_service/app/repair_pipeline.py
+++ b/ml_service/app/repair_pipeline.py
@@ -397,7 +397,7 @@ for context_type, templates in CONTEXT_TEMPLATES.items():
 print("Модель готова к использованию.\n")
 
 
-def count_matches(patterns: List, text: str) -> int:
+def count_matches(patterns: List, text: str) -> float:
     """Count pattern matches in text (wrapper for tests)."""
     count, _ = count_pattern_matches(patterns, text)
     return count


### PR DESCRIPTION
## Summary

Fixed mypy type error in the `count_matches` function by correcting the return type annotation from `int` to `float`.

## Issue

Fixes #3

The CI was failing with the following mypy error:
```
app/repair_pipeline.py:403: error: Incompatible return value type (got "float", expected "int")  [return-value]
```

## Root Cause

The `count_matches` function (ml_service/app/repair_pipeline.py:400) was annotated to return `int`, but it actually returns a `float`. This is because:

1. `count_matches` calls `count_pattern_matches(patterns, text)` which returns `Tuple[float, List[str]]`
2. The first element of this tuple (`weighted_count`) is a `float` value (initialized as `0.0` on line 503)
3. `count_matches` returns this `float` value, causing a type mismatch with the declared return type of `int`

## Solution

Changed the return type annotation of `count_matches` from `int` to `float` to match the actual return value type.

```python
# Before
def count_matches(patterns: List, text: str) -> int:

# After
def count_matches(patterns: List, text: str) -> float:
```

## Verification

All local checks pass:
- ✅ mypy: `Success: no issues found in 30 source files`
- ✅ ruff: `All checks passed!`
- ✅ black: `30 files would be left unchanged`

🤖 Generated with [Claude Code](https://claude.com/claude-code)